### PR TITLE
Migrate UI framework to Tailwind CSS with monotone colors

### DIFF
--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -1,0 +1,27 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Custom component classes */
+@layer components {
+  .menu-toggle-bar {
+    @apply block w-5 h-0.5 rounded-full absolute top-[18px] right-[7px] transition-all duration-500;
+  }
+
+  .menu-toggle-bar:first-child {
+    @apply -translate-y-1.5;
+  }
+
+  .menu-toggle.active .menu-toggle-bar {
+    @apply rotate-45;
+  }
+
+  .menu-toggle.active .menu-toggle-bar:first-child {
+    @apply -rotate-45 translate-y-0;
+  }
+}
+
+/* Custom styles for mobile menu animation */
+header.menu-wrapper {
+  transition: height 0.5s;
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,96 +1,10 @@
-.custom-wrapper {
-  background-color: #1976d2;
-  margin-bottom: 1em;
-  -webkit-font-smoothing: antialiased;
-  height: 2.5em;
-  overflow: hidden;
-  -webkit-transition: height 0.5s;
-  -moz-transition: height 0.5s;
-  -ms-transition: height 0.5s;
-  transition: height 0.5s;
-  padding-top: .5em;
-  padding-bottom: .5em;
-}
+/*! tailwindcss v3.4.1 | MIT License | https://tailwindcss.com */
+*,::after,::before{box-sizing:border-box;border-width:0;border-style:solid;border-color:#e5e7eb}::after,::before{--tw-content:''}:host,html{line-height:1.5;-webkit-text-size-adjust:100%;-moz-tab-size:4;tab-size:4;font-family:ui-sans-serif,system-ui,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";font-feature-settings:normal;font-variation-settings:normal;-webkit-tap-highlight-color:transparent}body{margin:0;line-height:inherit}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,pre,samp{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-feature-settings:normal;font-variation-settings:normal;font-size:1em}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}button,input,optgroup,select,textarea{font-family:inherit;font-feature-settings:inherit;font-variation-settings:inherit;font-size:100%;font-weight:inherit;line-height:inherit;color:inherit;margin:0;padding:0}button,select{text-transform:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button;background-color:transparent;background-image:none}:-moz-focusring{outline:auto}:-moz-ui-invalid{box-shadow:none}progress{vertical-align:baseline}::-webkit-inner-spin-button,::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}summary{display:list-item}blockquote,dd,dl,figure,h1,h2,h3,h4,h5,h6,hr,p,pre{margin:0}fieldset{margin:0;padding:0}legend{padding:0}menu,ol,ul{list-style:none;margin:0;padding:0}dialog{padding:0}textarea{resize:vertical}input::placeholder,textarea::placeholder{opacity:1;color:#9ca3af}[role=button],button{cursor:pointer}:disabled{cursor:default}audio,canvas,embed,iframe,img,object,svg,video{display:block;vertical-align:middle}img,video{max-width:100%;height:auto}[hidden]{display:none}*,::before,::after{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgb(59 130 246 / 0.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: }::backdrop{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgb(59 130 246 / 0.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: }
 
-.custom-wrapper.open {
-  height: 10em;
-}
+.menu-toggle-bar{position:absolute;top:18px;right:7px;display:block;height:.125rem;width:1.25rem;border-radius:9999px;transition-property:all;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.5s}.menu-toggle-bar:first-child{--tw-translate-y:-0.375rem;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.menu-toggle.active .menu-toggle-bar{--tw-rotate:45deg;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.menu-toggle.active .menu-toggle-bar:first-child{--tw-translate-y:0px;--tw-rotate:-45deg;transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 
-.custom-wrapper .pure-menu-list {
-  float: right;
-}
+header.menu-wrapper{transition:height .5s}
 
-.custom-wrapper .pure-menu-list .pure-menu-link {
-  color: #ffffff;
-}
+.container{width:100%}@media (min-width:640px){.container{max-width:640px}}@media (min-width:768px){.container{max-width:768px}}@media (min-width:1024px){.container{max-width:1024px}}@media (min-width:1280px){.container{max-width:1280px}}@media (min-width:1536px){.container{max-width:1536px}}
 
-.custom-brand {
-  color: #1976d2;
-}
-
-.custom-menu-3 {
-  text-align: right;
-}
-
-.custom-toggle {
-  width: 34px;
-  height: 34px;
-  display: block;
-  position: absolute;
-  top: .75em;
-  right: 0;
-  display: none;
-}
-
-.custom-toggle .bar {
-  background-color: #ffffff;
-  display: block;
-  width: 20px;
-  height: 2px;
-  border-radius: 100px;
-  position: absolute;
-  top: 18px;
-  right: 7px;
-  -webkit-transition: all 0.5s;
-  -moz-transition: all 0.5s;
-  -ms-transition: all 0.5s;
-  transition: all 0.5s;
-}
-
-.custom-toggle .bar:first-child {
-  -webkit-transform: translateY(-6px);
-  -moz-transform: translateY(-6px);
-  -ms-transform: translateY(-6px);
-  transform: translateY(-6px);
-}
-
-.custom-toggle.x .bar {
-  -webkit-transform: rotate(45deg);
-  -moz-transform: rotate(45deg);
-  -ms-transform: rotate(45deg);
-  transform: rotate(45deg);
-}
-
-.custom-toggle.x .bar:first-child {
-  -webkit-transform: rotate(-45deg);
-  -moz-transform: rotate(-45deg);
-  -ms-transform: rotate(-45deg);
-  transform: rotate(-45deg);
-}
-
-@media (max-width: 47.999em) {
-  .open .custom-menu-3 {
-    text-align: left;
-  }
-  .custom-toggle {
-    display: block;
-  }
-}
-
-#menu {
-  padding-top: 0.5em;
-}
-
-article {
-  padding-left: .5em;
-}
+.absolute{position:absolute}.relative{position:relative}.right-4{right:1rem}.top-3{top:.75rem}.mx-auto{margin-left:auto;margin-right:auto}.mb-4{margin-bottom:1rem}.mt-2{margin-top:.5rem}.block{display:block}.flex{display:flex}.h-10{height:2.5rem}.h-8{height:2rem}.h-auto{height:auto}.w-8{width:2rem}.w-full{width:100%}.list-none{list-style-type:none}.list-disc{list-style-type:disc}.flex-col{flex-direction:column}.flex-wrap{flex-wrap:wrap}.items-center{align-items:center}.justify-between{justify-content:space-between}.space-y-1>:not([hidden])~:not([hidden]){--tw-space-y-reverse:0;margin-top:calc(.25rem * calc(1 - var(--tw-space-y-reverse)));margin-bottom:calc(.25rem * var(--tw-space-y-reverse))}.space-y-2>:not([hidden])~:not([hidden]){--tw-space-y-reverse:0;margin-top:calc(.5rem * calc(1 - var(--tw-space-y-reverse)));margin-bottom:calc(.5rem * var(--tw-space-y-reverse))}.overflow-hidden{overflow:hidden}.bg-gray-800{--tw-bg-opacity:1;background-color:rgb(31 41 55 / var(--tw-bg-opacity))}.bg-white{--tw-bg-opacity:1;background-color:rgb(255 255 255 / var(--tw-bg-opacity))}.px-4{padding-left:1rem;padding-right:1rem}.py-2{padding-top:.5rem;padding-bottom:.5rem}.py-4{padding-top:1rem;padding-bottom:1rem}.pl-5{padding-left:1.25rem}.pt-2{padding-top:.5rem}.text-2xl{font-size:1.5rem;line-height:2rem}.font-bold{font-weight:700}.text-gray-700{--tw-text-opacity:1;color:rgb(55 65 81 / var(--tw-text-opacity))}.text-gray-800{--tw-text-opacity:1;color:rgb(31 41 55 / var(--tw-text-opacity))}.text-gray-900{--tw-text-opacity:1;color:rgb(17 24 39 / var(--tw-text-opacity))}.text-white{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}.transition-all{transition-property:all;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.transition-colors{transition-property:color,background-color,border-color,text-decoration-color,fill,stroke;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.duration-500{transition-duration:.5s}.hover\:text-gray-300:hover{--tw-text-opacity:1;color:rgb(209 213 219 / var(--tw-text-opacity))}@media (min-width:768px){.md\:h-auto{height:auto}.md\:w-1\/3{width:33.333333%}.md\:w-2\/3{width:66.666667%}.md\:flex-row{flex-direction:row}.md\:justify-end{justify-content:flex-end}.md\:space-x-6>:not([hidden])~:not([hidden]){--tw-space-x-reverse:0;margin-right:calc(1.5rem * var(--tw-space-x-reverse));margin-left:calc(1.5rem * calc(1 - var(--tw-space-x-reverse)))}.md\:space-y-0>:not([hidden])~:not([hidden]){--tw-space-y-reverse:0;margin-top:calc(0px * calc(1 - var(--tw-space-y-reverse)));margin-bottom:calc(0px * var(--tw-space-y-reverse))}.md\:hidden{display:none}}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2,37 +2,31 @@
     var menu = document.getElementsByTagName('header')[0],
         WINDOW_CHANGE_EVENT = ('onorientationchange' in window) ? 'orientationchange' : 'resize';
 
-    function toggleHorizontal() {
-        [].forEach.call(
-            document.getElementsByTagName('header')[0].querySelectorAll('.custom-can-transform'),
-            function(el) {
-                el.classList.toggle('pure-menu-horizontal');
-            }
-        );
-    };
-
     function toggleMenu() {
-        // set timeout so that the panel has a chance to roll up
-        // before the menu switches states
-        if (menu.classList.contains('open')) {
-            setTimeout(toggleHorizontal, 500);
+        var header = menu;
+        if (header.classList.contains('h-10')) {
+            header.classList.remove('h-10');
+            header.classList.add('h-auto');
         } else {
-            toggleHorizontal();
+            header.classList.add('h-10');
+            header.classList.remove('h-auto');
         }
-        menu.classList.toggle('open');
-        document.getElementById('toggle').classList.toggle('x');
+        document.getElementById('toggle').classList.toggle('active');
     };
 
     function closeMenu() {
-        if (menu.classList.contains('open')) {
+        if (!menu.classList.contains('h-10')) {
             toggleMenu();
         }
     }
 
-    document.getElementById('toggle').addEventListener('click', function(e) {
-        toggleMenu();
-        e.preventDefault();
-    });
+    var toggleEl = document.getElementById('toggle');
+    if (toggleEl) {
+        toggleEl.addEventListener('click', function(e) {
+            toggleMenu();
+            e.preventDefault();
+        });
+    }
 
     window.addEventListener(WINDOW_CHANGE_EVENT, closeMenu);
 })(this, this.document);

--- a/index.html
+++ b/index.html
@@ -5,47 +5,45 @@
     <meta charset="utf-8">
     <title>arc680</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="https://unpkg.com/purecss@0.6.2/build/pure-min.css">
-    <!--[if lte IE 8]>
-          <link rel="stylesheet" href="https://unpkg.com/purecss@0.6.2/build/grids-responsive-old-ie-min.css">
-      <![endif]-->
-    <!--[if gt IE 8]><!-->
-    <link rel="stylesheet" href="https://unpkg.com/purecss@0.6.2/build/grids-responsive-min.css">
-    <!--<![endif]-->
     <link rel="stylesheet" href="assets/css/style.css">
 </head>
 
-<body>
+<body class="bg-white text-gray-900">
 
-    <header class="custom-wrapper pure-g">
-        <div class="pure-u-1 pure-u-md-1-3">
-            <div class="pure-menu">
-                <span class="pure-menu-heading custom-brand">&nbsp;</span>
-                <a href="#" class="custom-toggle" id="toggle"><s class="bar"></s><s class="bar"></s></a>
+    <header class="menu-wrapper bg-gray-800 mb-4 overflow-hidden h-10 md:h-auto transition-all duration-500" id="header">
+        <div class="container mx-auto px-4">
+            <div class="flex flex-wrap items-center justify-between">
+                <div class="w-full md:w-1/3">
+                    <div class="py-2">
+                        <span class="text-gray-800">&nbsp;</span>
+                        <a href="#" class="menu-toggle w-8 h-8 block absolute top-3 right-4 md:hidden" id="toggle">
+                            <span class="menu-toggle-bar bg-white"></span>
+                            <span class="menu-toggle-bar bg-white"></span>
+                        </a>
+                    </div>
+                </div>
+                <nav class="w-full md:w-2/3 pt-2" id="menu">
+                    <ul class="flex flex-col md:flex-row md:justify-end space-y-2 md:space-y-0 md:space-x-6 list-none" id="menu-list">
+                        <li><a href="https://twitter.com/arc680" class="text-white hover:text-gray-300 transition-colors">Twitter</a></li>
+                        <li><a href="https://github.com/arc680" class="text-white hover:text-gray-300 transition-colors">Github</a></li>
+                        <li><a href="http://arc680.hatenablog.jp/" class="text-white hover:text-gray-300 transition-colors">Blog</a></li>
+                    </ul>
+                </nav>
             </div>
-        </div>
-        <div class="pure-u-1 pure-u-md-2-3" id="menu">
-            <div class="pure-menu pure-menu-horizontal custom-can-transform">
-                <ul class="pure-menu-list" id="menu-list">
-                    <li class="pure-menu-item"><a href="https://twitter.com/arc680" class="pure-menu-link">Twitter</a></li>
-                    <li class="pure-menu-item"><a href="https://github.com/arc680" class="pure-menu-link">Github</a></li>
-                    <li class="pure-menu-item"><a href="http://arc680.hatenablog.jp/" class="pure-menu-link">Blog</a></li>
-                </ul>
-            </div>
-        </div>
         </div>
     </header>
 
-    <article>
-      <h2>arc680</h2>
-      <ul>
-        <li>一応 Web 系エンジニア</li>
-          <ul>
+    <article class="container mx-auto px-4 py-4">
+      <h2 class="text-2xl font-bold mb-4 text-gray-900">arc680</h2>
+      <ul class="list-disc pl-5 space-y-2 text-gray-700">
+        <li>一応 Web 系エンジニア
+          <ul class="list-disc pl-5 mt-2 space-y-1">
             <li>仕事だと PHP や JavaScript がメイン</li>
             <li>遊びだと Ruby</li>
           </ul>
-          <li>ゲームやアニメを嗜む</li>
-          <li>端末はそんなに持ってない</li>
+        </li>
+        <li>ゲームやアニメを嗜む</li>
+        <li>端末はそんなに持ってない</li>
       </ul>
     </article>
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "arc680-github-io",
+  "version": "1.0.0",
+  "description": "Personal website for arc680",
+  "scripts": {
+    "build:css": "tailwindcss -i ./assets/css/input.css -o ./assets/css/style.css --minify"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.4.1"
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,27 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./*.html",
+    "./assets/js/**/*.js"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        // Monotone color palette
+        primary: {
+          50: '#f9fafb',
+          100: '#f3f4f6',
+          200: '#e5e7eb',
+          300: '#d1d5db',
+          400: '#9ca3af',
+          500: '#6b7280',
+          600: '#4b5563',
+          700: '#374151',
+          800: '#1f2937',
+          900: '#111827',
+        }
+      }
+    },
+  },
+  plugins: [],
+}


### PR DESCRIPTION
Closes #3

## Summary
- Migrated from PureCSS to Tailwind CSS
- Implemented monotone color scheme using gray scale
- Preserved all existing content
- Updated JavaScript for Tailwind-based menu toggle

## Changes
- Removed PureCSS CDN links
- Added Tailwind CSS utility classes throughout HTML
- Created Tailwind configuration with monotone palette
- Added build setup files (package.json, tailwind.config.js)

🤖 Generated with [Claude Code](https://claude.ai/code)